### PR TITLE
SSL verification and plugin disabling

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ submitting feature requests or issues to [issues][githubissues].
 
 ## Requires
 * pytest >= 2.2.3
-* jira >= 0.13
+* jira >= 0.43
 
 ## Installation
 ``pip install pytest_jira``
@@ -38,6 +38,8 @@ submitting feature requests or issues to [issues][githubissues].
     url = https://jira.atlassian.com
     username = USERNAME (or blank for no authentication)
     password = PASSWORD (or blank for no authentication)
+    # ssl_verification = True/False
+
     ```
 
 Options can be overridden with command line options.

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     py_modules=['pytest_jira'],
     entry_points = {'pytest11': ['pytest_jira = pytest_jira'],},
     zip_safe=False,
-    install_requires = ['jira>=0.13','pytest>=2.2.4'],
+    install_requires = ['jira>=0.43','pytest>=2.2.4'],
     cmdclass = {'test': PyTest,
                 'clean': CleanCommand,
                 # 'build_sphinx': BuildSphinx},


### PR DESCRIPTION
1) if connection to Jira wasn't established, plugin won't be loaded
2) it's possible to disable ssl verification to jira